### PR TITLE
Fixed mislabelled property in search-cards.mdx 

### DIFF
--- a/docs/api-reference/cards/search-cards.mdx
+++ b/docs/api-reference/cards/search-cards.mdx
@@ -218,7 +218,7 @@ pokemon.card.where({ pageSize: 250, page: 1 })
   })
 
 // Filter cards via query parameters
-pokemon.card.all({ q: 'set.id:generations subtypes:mega' })
+pokemon.card.all({ q: 'set.name:generations subtypes:mega' })
   .then(result => {
       console.log(result.data[0].name) // "Venusaur"
   })
@@ -241,7 +241,7 @@ curl "https://api.pokemontcg.io/v2/cards"
 curl "https://api.pokemontcg.io/v2/cards?page=1&pageSize=250"
 
 # Filter cards via query parameters
-curl "https://api.pokemontcg.io/v2/cards?q=set.id:generations subtypes:mega"
+curl "https://api.pokemontcg.io/v2/cards?q=set.name:generations subtypes:mega"
 
 # Order by release date (descending)
 curl "https://api.pokemontcg.io/v2/cards?q=subtypes:mega&orderBy=-set.releaseDate"


### PR DESCRIPTION
Within the search-cards markdown file there was two instances of "set.id:generations" which seemed to be a mistake as in the same file there was also "set.name:generations" being used. 

This request simply changes the instances of set.id to make the page consistent and create working examples.